### PR TITLE
Add PostGIS support and missing network fields to Measurement model

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, Float, String, TIMESTAMP
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import Column, Integer, Float, String, TIMESTAMP, Index
+from sqlalchemy.dialects.postgresql import UUID, GEOGRAPHY
+from sqlalchemy.sql import func
 from app.database import Base
 
 
@@ -9,23 +10,41 @@ class Measurement(Base):
     id = Column(Integer, primary_key=True, index=True)
     session_id = Column(UUID, nullable=False)
 
+    # id użytkownika
     imsi = Column(String, nullable=False)
+    # id urządzenia
     imei = Column(String)
 
+    # czas
     measured_at = Column(TIMESTAMP(timezone=True), nullable=False)
 
+    # lokalizacja
+    location = Column(GEOGRAPHY(geometry_type='POINT', srid=4326))
     latitude = Column(Float)
     longitude = Column(Float)
 
+    # parametry sieci
     rsrp = Column(Integer)
+    rsrq = Column(Integer)
     sinr = Column(Integer)
     network_type = Column(String)
     cell_id = Column(String)
+    tac = Column(Integer)
+    band = Column(Integer)
 
+    # parametry systemowe
     battery_level = Column(Integer)
     processor_temp = Column(Float)
     os_version = Column(String)
 
+    # testy wydajności
     throughput_mbps = Column(Float)
     test_start_time = Column(TIMESTAMP(timezone=True))
     test_end_time = Column(TIMESTAMP(timezone=True))
+
+    # indeksy do wydajności
+    __table_args__ = (
+        Index('ids_measurements_location', location, postgersql_using='gist'),
+        Index('idx_measurements_time', measure_at),
+        Index('idx_measurement_cell', cell_id),
+    )


### PR DESCRIPTION
Added:
- PostGIS geography column 'location'
- 'rsrq' field (Reference Signal Received Quality)
- 'tac' field (Tracking Area Code)
- 'band' field (frequency band)
- 'network_mode' field (5G/NSA/SA/LTE/WCDMA/GSM)
- Spatial index on 'location' using GIST
- Time index on 'measured_at'
- Index on 'cell_id' for faster grouping