### PR TITLE
Dev/android UI

### DIFF
--- a/androidApp/app/build.gradle.kts
+++ b/androidApp/app/build.gradle.kts
@@ -64,6 +64,21 @@ android {
         }
     }
 
+    // prevent some names optimizations
+    buildTypes {
+        // not used anyway
+        release {
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+        debug {
+            isMinifyEnabled = false
+        }
+    }
+
     buildFeatures {
         compose = true
     }

--- a/androidApp/app/proguard-rules.pro
+++ b/androidApp/app/proguard-rules.pro
@@ -1,0 +1,6 @@
+-keep class edu.pwr.zpi.netwalk.iperf.** { *; }
+-keep interface edu.pwr.zpi.netwalk.iperf.** { *; }
+
+-keepclassmembers class edu.pwr.zpi.netwalk.iperf.IperfRunner {
+    native <methods>;
+}

--- a/androidApp/app/src/main/AndroidManifest.xml
+++ b/androidApp/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <application
         android:label="@string/app_name"
         android:theme="@style/Theme.NetWalk"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:usesCleartextTraffic="true">
         <!-- usesCleartextTraffici tylko dla lokalnych testow, dozwala http zamiast https -->
 

--- a/androidApp/app/src/main/cpp/CMakeLists.txt
+++ b/androidApp/app/src/main/cpp/CMakeLists.txt
@@ -33,6 +33,9 @@ configure_file(
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
+# Possibly prevents linker policy violation
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Declare native shared library
 add_library(netwalkIperf SHARED
         ${JNI_SRC_FILE}                        # JNI interface

--- a/androidApp/app/src/main/cpp/iperf/iperf_config_android.h
+++ b/androidApp/app/src/main/cpp/iperf/iperf_config_android.h
@@ -77,14 +77,12 @@
 #define PACKAGE_URL "https://software.es.net/iperf/"
 #define PACKAGE_VERSION "3.21"
 #define VERSION "3.21"
-// ──────────────────────────────
-// SECTION TO UPDATE ON IPERF VERSION UPGRADE
-// (Update version strings when pulling new iperf source)
-// ──────────────────────────────
-#define PACKAGE_STRING "iperf @PACKAGE_VERSION@" // Auto Update
-#define PACKAGE_VERSION "@PACKAGE_VERSION@"      // Auto Update
-#define VERSION "@PACKAGE_VERSION@"              // Auto Update
 
 #define STDC_HEADERS 1 // Define if ANSI C headers are available
+
+// one of possible fix for network socket hang
+#define HAVE_GETADDRINFO 1
+#define HAVE_GETNAMEINFO 1
+#define HAVE_STRUCT_SOCKADDR_STORAGE 1
 
 /* #undef const */ // Do not touch — reserved for legacy platforms

--- a/androidApp/app/src/main/cpp/iperf/iperf_jni.c
+++ b/androidApp/app/src/main/cpp/iperf/iperf_jni.c
@@ -44,7 +44,10 @@ struct CallbackArgs {
 void *readerThreadFunc(void *args_ptr) {
     struct CallbackArgs *args = (struct CallbackArgs *)args_ptr;
     JNIEnv *env;
+    LOGI("[JNI_TRACK] readerThreadFunc spawned. Attaching current thread to "
+         "JVM.");
     (*args->jvm)->AttachCurrentThread(args->jvm, &env, NULL);
+    LOGI("[JNI_TRACK] Thread successfully attached to JVM.");
 
     jclass callbackClass = (*env)->GetObjectClass(env, args->callback_global);
     jmethodID onOutput = (*env)->GetMethodID(env, callbackClass, "onOutput",
@@ -53,16 +56,19 @@ void *readerThreadFunc(void *args_ptr) {
     char buffer[1024];
     FILE *fp = fdopen(args->pipe_fd, "r");
 
+    LOGI("[JNI_TRACK] Starting pipe reading loop...");
     while (fgets(buffer, sizeof(buffer), fp)) {
         jstring line = (*env)->NewStringUTF(env, buffer);
         (*env)->CallVoidMethod(env, args->callback_global, onOutput, line);
         (*env)->DeleteLocalRef(env, line);
     }
+    LOGI("[JNI_TRACK] Pipe reading loop exited (EOF reached or pipe broken).");
 
     fclose(fp);
     (*env)->DeleteGlobalRef(env, args->callback_global);
     (*args->jvm)->DetachCurrentThread(args->jvm);
     free(args);
+    LOGI("[JNI_TRACK] Reader thread detached and fully closed.");
     return NULL;
 }
 
@@ -75,6 +81,7 @@ void *readerThreadFunc(void *args_ptr) {
 JNIEXPORT void JNICALL
 Java_edu_pwr_zpi_netwalk_iperf_IperfRunner_forceStopIperfTest(
     JNIEnv *env, jobject thiz, jobject callback) {
+    LOGI("[JNI_TRACK] forceStopIperfTest called from Kotlin.");
     stop_requested = true;
 
     jclass callbackClass = (*env)->GetObjectClass(env, callback);
@@ -102,6 +109,8 @@ Java_edu_pwr_zpi_netwalk_iperf_IperfRunner_forceStopIperfTest(
  */
 JNIEXPORT void JNICALL Java_edu_pwr_zpi_netwalk_iperf_IperfRunner_runIperfLive(
     JNIEnv *env, jobject thiz, jobjectArray arguments, jobject callback) {
+    LOGI("[JNI_TRACK] Entered runIperfLive JNI method");
+
     jclass callbackClass = (*env)->GetObjectClass(env, callback);
     jmethodID onOutput = (*env)->GetMethodID(env, callbackClass, "onOutput",
                                              "(Ljava/lang/String;)V");
@@ -115,6 +124,7 @@ JNIEXPORT void JNICALL Java_edu_pwr_zpi_netwalk_iperf_IperfRunner_runIperfLive(
     if (argc > 64)
         argc = 64;
 
+    LOGI("[JNI_TRACK] Parsing Kotlin arguments array. Size: %d", argc);
     char *argv[64];
     for (int i = 0; i < argc; i++) {
         jstring arg = (jstring)(*env)->GetObjectArrayElement(env, arguments, i);
@@ -124,8 +134,10 @@ JNIEXPORT void JNICALL Java_edu_pwr_zpi_netwalk_iperf_IperfRunner_runIperfLive(
     }
 
     // ───── Create and initialize iperf test ─────
+    LOGI("[JNI_TRACK] Allocating iperf_new_test...");
     global_test = iperf_new_test();
     if (!global_test) {
+        LOGE("[JNI_TRACK] CRITICAL: Failed to create iperf test instance.");
         jstring errMsg =
             (*env)->NewStringUTF(env, "Failed to create iperf test");
         (*env)->CallVoidMethod(env, callback, onError, errMsg);
@@ -135,6 +147,7 @@ JNIEXPORT void JNICALL Java_edu_pwr_zpi_netwalk_iperf_IperfRunner_runIperfLive(
     iperf_defaults(global_test);
 
     // ───── Setup pipe to capture iperf output ─────
+    LOGI("[JNI_TRACK] Setting up internal POSIX output pipes...");
     int pipefd[2];
     if (pipe(pipefd) < 0) {
         jstring errMsg =
@@ -150,7 +163,9 @@ JNIEXPORT void JNICALL Java_edu_pwr_zpi_netwalk_iperf_IperfRunner_runIperfLive(
     global_test->outfile = fp;
 
     // ───── Parse iperf arguments ─────
+    LOGI("[JNI_TRACK] Passing argv map to iperf_parse_arguments...");
     if (iperf_parse_arguments(global_test, argc, argv) < 0) {
+        LOGE("[JNI_TRACK] Parse Error: %s", iperf_strerror(i_errno));
         fflush(fp);
         fclose(fp);
 
@@ -162,11 +177,14 @@ JNIEXPORT void JNICALL Java_edu_pwr_zpi_netwalk_iperf_IperfRunner_runIperfLive(
     }
 
     // ───── Start reader thread ─────
+    LOGI("[JNI_TRACK] Creating background pthread for output handling...");
     struct CallbackArgs *cb_args = malloc(sizeof(struct CallbackArgs));
     (*env)->GetJavaVM(env, &cb_args->jvm);
     cb_args->callback_global = (*env)->NewGlobalRef(env, callback);
     cb_args->pipe_fd = pipefd[0];
-    pthread_create(&reader_thread, NULL, readerThreadFunc, cb_args);
+    int thread_status =
+        pthread_create(&reader_thread, NULL, readerThreadFunc, cb_args);
+    LOGI("[JNI_TRACK] pthread_create code returned status: %d", thread_status);
 
     // ───── Notify start ─────
     // REMOVED MESSAGE
@@ -176,14 +194,21 @@ JNIEXPORT void JNICALL Java_edu_pwr_zpi_netwalk_iperf_IperfRunner_runIperfLive(
     // (*env)->DeleteLocalRef(env, initMsg);
 
     // ───── Run the test ─────
+    LOGI("[JNI_TRACK] !!! Launching blocking iperf_run_client loop !!!");
     int result = iperf_run_client(global_test);
+    LOGI("[JNI_TRACK] iperf_run_client returned execution to JNI with result "
+         "flag: %d",
+         result);
     if (result < 0 && global_test) {
+        LOGE("[JNI_TRACK] Core execution failure code: %s",
+             iperf_strerror(i_errno));
         jstring errMsg = (*env)->NewStringUTF(env, iperf_strerror(i_errno));
         (*env)->CallVoidMethod(env, callback, onError, errMsg);
         (*env)->DeleteLocalRef(env, errMsg);
     }
 
     // ───── Cleanup ─────
+    LOGI("[JNI_TRACK] Commencing resource cleanup...");
     fflush(fp);
     fclose(fp);
 
@@ -192,7 +217,9 @@ JNIEXPORT void JNICALL Java_edu_pwr_zpi_netwalk_iperf_IperfRunner_runIperfLive(
         global_test = NULL;
     }
 
+    LOGI("[JNI_TRACK] Waiting for reader thread to join...");
     pthread_join(reader_thread, NULL);
+    LOGI("[JNI_TRACK] Reader thread joined successfully.");
 
     for (int i = 0; i < argc; i++) {
         free(argv[i]);
@@ -219,5 +246,7 @@ JNIEXPORT void JNICALL Java_edu_pwr_zpi_netwalk_iperf_IperfRunner_runIperfLive(
     reader_thread = 0;
 
     // ───── Notify completion to Java ─────
+    LOGI("[JNI_TRACK] Invoking onComplete Kotlin callback hook. Execution "
+         "complete.");
     (*env)->CallVoidMethod(env, callback, onComplete);
 }

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/MainActivity.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/MainActivity.kt
@@ -81,27 +81,31 @@ class MainActivity : ComponentActivity() {
                 Scaffold(
                     containerColor = MaterialTheme.colorScheme.background,
                     bottomBar = {
-                        NavigationBar(
-                            containerColor = MaterialTheme.colorScheme.surface,
-                        ) {
-                            val navBackStackEntry by navController.currentBackStackEntryAsState()
-                            val currentRoute = navBackStackEntry?.destination?.route
+                        val navBackStackEntry by navController.currentBackStackEntryAsState()
+                        val currentRoute = navBackStackEntry?.destination?.route
 
-                            items.forEach { item ->
-                                NavigationBarItem(
-                                    icon = { Icon(imageVector = item.icon, contentDescription = item.title) },
-                                    label = { Text(item.title) },
-                                    selected = currentRoute == item.route,
-                                    onClick = {
-                                        navController.navigate(item.route) {
-                                            popUpTo(navController.graph.findStartDestination().id) {
-                                                saveState = true
+                        val shouldShowBottomBar = items.any { it.route == currentRoute }
+
+                        if (shouldShowBottomBar) {
+                            NavigationBar(
+                                containerColor = MaterialTheme.colorScheme.surface,
+                            ) {
+                                items.forEach { item ->
+                                    NavigationBarItem(
+                                        icon = { Icon(imageVector = item.icon, contentDescription = item.title) },
+                                        label = { Text(item.title) },
+                                        selected = currentRoute == item.route,
+                                        onClick = {
+                                            navController.navigate(item.route) {
+                                                popUpTo(navController.graph.findStartDestination().id) {
+                                                    saveState = true
+                                                }
+                                                launchSingleTop = true
+                                                restoreState = true
                                             }
-                                            launchSingleTop = true
-                                            restoreState = true
-                                        }
-                                    },
-                                )
+                                        },
+                                    )
+                                }
                             }
                         }
                     },

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/collector/DataCollector.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/collector/DataCollector.kt
@@ -70,6 +70,7 @@ class DataCollector(
 
                         val now = System.currentTimeMillis()
                         // TODO: add check for busy iperf server OR server-side connection manager / port rotation
+                        // TODO: add repeat with delay if cpu is too high
                         var shouldRunIperf = now - lastIperfTime > currentIperfInterval
 
                         if (shouldForceIperf()) {

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/collector/DataCollector.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/collector/DataCollector.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 
 class DataCollector(
     private val scope: CoroutineScope,
-    private val getIperfCommand: () -> Array<String>,
+    private val getIperfCommand: (isDownload: Boolean) -> Array<String>,
     private val onStatusUpdate: (String) -> Unit,
     private val onPassiveDataUpdate: (NetworkInfoData?, Pair<Double?, Double?>, SystemData?) -> Unit,
     private val sendRequest: suspend (MeasurementRequest) -> Unit,
@@ -81,12 +81,12 @@ class DataCollector(
                             lastIperfTime = now
                             try {
                                 withContext(Dispatchers.IO) {
-                                    // TODO: add -R argument
                                     val ulResuls = withTimeoutOrNull(currentTimout) {
-                                        IperfRunner.runIperfOnce(getIperfCommand())
+                                        // named args are prohibited in labdas
+                                        IperfRunner.runIperfOnce(getIperfCommand(false)) // isDownload=false
                                     }
                                     val dlResult = withTimeoutOrNull(currentTimout) {
-                                        IperfRunner.runIperfOnce(getIperfCommand())
+                                        IperfRunner.runIperfOnce(getIperfCommand(true)) // isDownload=true
                                     }
                                     Pair(ulResuls, dlResult)
                                 }

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/collector/DataCollector.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/collector/DataCollector.kt
@@ -29,7 +29,7 @@ class DataCollector(
     private val sendRequest: suspend (MeasurementRequest) -> Unit,
     private val shouldForceIperf: () -> Boolean,
     private val onForceIperfHandled: () -> Unit,
-    private val onIperfRawResult: (String) -> Unit,
+    private val onIperfRawResult: (String?, String?) -> Unit,
 ) {
     private var job: Job? = null
     private var lastIperfTime = 0L
@@ -77,23 +77,28 @@ class DataCollector(
                             onForceIperfHandled()
                         }
 
-                        val iperfResult = if (shouldRunIperf) {
+                        val (iperfUploadResult, iperfDownloadResult) = if (shouldRunIperf) {
                             lastIperfTime = now
                             try {
                                 withContext(Dispatchers.IO) {
-                                    withTimeoutOrNull(currentTimout) {
+                                    // TODO: add -R argument
+                                    val ulResuls = withTimeoutOrNull(currentTimout) {
                                         IperfRunner.runIperfOnce(getIperfCommand())
                                     }
+                                    val dlResult = withTimeoutOrNull(currentTimout) {
+                                        IperfRunner.runIperfOnce(getIperfCommand())
+                                    }
+                                    Pair(ulResuls, dlResult)
                                 }
                             } catch (e: Exception) {
-                                null
+                                Pair(null, null)
                             }
                         } else {
-                            null
+                            Pair(null, null)
                         }
 
-                        if (iperfResult != null) {
-                            onIperfRawResult(iperfResult)
+                        if (iperfUploadResult != null || iperfDownloadResult != null) {
+                            onIperfRawResult(iperfUploadResult, iperfDownloadResult)
                         }
 
                         val request = networkData.toMeasurementsRequest(
@@ -101,7 +106,8 @@ class DataCollector(
                             latitude = locationData.first,
                             longitude = locationData.second,
                             systemData = systemData,
-                            iperfRaw = iperfResult,
+                            iperfUlRaw = iperfUploadResult,
+                            iperfDlRaw = iperfDownloadResult,
                             measuredAtNow = now,
                         )
 

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/fetcher/NetworkInfoFetcher.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/fetcher/NetworkInfoFetcher.kt
@@ -54,6 +54,9 @@ data class MeasurementItem(
     val host_cpu: Double? = null,
     val remote_cpu: Double? = null,
     val retransmits: Long? = null,
+    val is_udp: Boolean? = null,
+    val lost_packets: Long? = null,
+    val lost_percent: Double? = null,
     val iperf_json: String? = null,
 ) {
     constructor (
@@ -103,6 +106,9 @@ data class MeasurementItem(
         host_cpu = iperf?.hostCpuTotal,
         remote_cpu = iperf?.remoteCpuTotal,
         retransmits = iperf?.retransmits,
+        is_udp = iperf?.isUdp,
+        lost_packets = iperf?.lostPackets,
+        lost_percent = iperf?.lostPercent,
         iperf_json = iperfRaw, // optional, normally empty
     )
 

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/fetcher/NetworkInfoFetcher.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/fetcher/NetworkInfoFetcher.kt
@@ -13,6 +13,7 @@ import android.telephony.TelephonyManager
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import edu.pwr.zpi.netwalk.iperf.IperfParsed
+import edu.pwr.zpi.netwalk.iperf.RttPoint
 import edu.pwr.zpi.netwalk.iperf.parseIperfJsonSafe
 import edu.pwr.zpi.netwalk.system.SystemData
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -108,14 +109,9 @@ data class MeasurementItem(
         battery_temp = system.battery_temp,
         os_version = system.os_version,
         //
-        // TODO: fix udp latency and jitter
         ul_throughput_mbps = iperfUl?.throughputMbps,
         ul_latency_ms = iperfUl?.meanRtt,
-        ul_jitter_ms = if (iperfUl?.maxRtt != null && iperfUl.minRtt != null) {
-            (iperfUl.maxRtt - iperfUl.minRtt)
-        } else {
-            null
-        },
+        ul_jitter_ms = iperfUl?.jitterMs ?: calculateTcpJitterMs(iperfUl?.rttTimeline),
         ul_mean_rtt = iperfUl?.meanRtt,
         ul_min_rtt = iperfUl?.minRtt,
         ul_max_rtt = iperfUl?.maxRtt,
@@ -125,11 +121,7 @@ data class MeasurementItem(
         //
         dl_throughput_mbps = iperfDl?.throughputMbps,
         dl_latency_ms = iperfDl?.meanRtt,
-        dl_jitter_ms = if (iperfDl?.maxRtt != null && iperfDl.minRtt != null) {
-            (iperfDl.maxRtt - iperfDl.minRtt)
-        } else {
-            null
-        },
+        dl_jitter_ms = iperfDl?.jitterMs ?: calculateTcpJitterMs(iperfDl?.rttTimeline),
         dl_mean_rtt = iperfDl?.meanRtt,
         dl_min_rtt = iperfDl?.minRtt,
         dl_max_rtt = iperfDl?.maxRtt,
@@ -163,6 +155,24 @@ data class MeasurementItem(
             } catch (e: Exception) {
                 null
             }
+
+        // calculating jitter according to RFC 3550
+        private fun calculateTcpJitterMs(rttTimeline: List<RttPoint>?): Double? {
+            if (rttTimeline.isNullOrEmpty() || rttTimeline.size < 2) return null
+
+            var calculatedJitter = 0.0
+
+            for (i in 1 until rttTimeline.size) {
+                val currentRtt = rttTimeline[i].rtt
+                val previousRtt = rttTimeline[i - 1].rtt
+
+                val delta = kotlin.math.abs(currentRtt - previousRtt)
+                calculatedJitter += (delta - calculatedJitter) / 16.0
+            }
+
+            // iperf3 RTT values are in microseconds; convert to milliseconds
+            return calculatedJitter / 1000.0
+        }
     }
 }
 

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/fetcher/NetworkInfoFetcher.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/fetcher/NetworkInfoFetcher.kt
@@ -70,7 +70,7 @@ data class MeasurementItem(
     val host_cpu: Double? = null, // we are taking max, since whole test must be repeated if load is too high
     val remote_cpu: Double? = null,
     //
-    val is_udp: Boolean? = null,
+    val protocol: String? = null,
     val iperf_ul_json: String? = null,
     val iperf_dl_json: String? = null,
 ) {
@@ -142,7 +142,7 @@ data class MeasurementItem(
         host_cpu = listOfNotNull(iperfUl?.hostCpuTotal, iperfDl?.hostCpuTotal).maxOrNull(),
         remote_cpu = listOfNotNull(iperfUl?.remoteCpuTotal, iperfDl?.remoteCpuTotal).maxOrNull(),
         //
-        is_udp = iperfUl?.isUdp,
+        protocol = resolveProtocol(iperfUl?.protocol, iperfDl?.protocol),
         iperf_ul_json = iperfUlRaw, // optional, normally empty
         iperf_dl_json = iperfDlRaw, // optional, normally empty
     )
@@ -173,6 +173,18 @@ data class MeasurementItem(
             // iperf3 RTT values are in microseconds; convert to milliseconds
             return calculatedJitter / 1000.0
         }
+
+        private fun resolveProtocol(
+            ulProto: String?,
+            dlProto: String?,
+        ): String? =
+            when {
+                ulProto != null && dlProto != null && ulProto == dlProto -> ulProto
+                ulProto != null && dlProto == null -> ulProto
+                dlProto != null && ulProto == null -> dlProto
+                ulProto != null && dlProto != null && ulProto != dlProto -> "MIXED"
+                else -> null
+            }
     }
 }
 

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/fetcher/NetworkInfoFetcher.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/fetcher/NetworkInfoFetcher.kt
@@ -42,22 +42,36 @@ data class MeasurementItem(
     val battery_level: Int? = null,
     val battery_temp: Double? = null,
     val os_version: String? = null,
-    val throughput_mbps: Double? = null,
-    val latency_ms: Double? = null,
-    val jitter_ms: Double? = null,
-    val cpu_utilization: Double? = null,
+    //
+    val ul_throughput_mbps: Double? = null,
+    val ul_latency_ms: Double? = null,
+    val ul_jitter_ms: Double? = null,
+    val ul_mean_rtt: Double? = null,
+    val ul_min_rtt: Double? = null,
+    val ul_max_rtt: Double? = null,
+    val ul_retransmits: Long? = null,
+    val ul_lost_packets: Long? = null,
+    val ul_lost_percent: Double? = null,
+    //
+    val dl_throughput_mbps: Double? = null,
+    val dl_latency_ms: Double? = null,
+    val dl_jitter_ms: Double? = null,
+    val dl_mean_rtt: Double? = null,
+    val dl_min_rtt: Double? = null,
+    val dl_max_rtt: Double? = null,
+    val dl_retransmits: Long? = null,
+    val dl_lost_packets: Long? = null,
+    val dl_lost_percent: Double? = null,
+    //
     val test_start_time: String? = null,
     val test_duration: Double? = null,
-    val mean_rtt: Double? = null,
-    val min_rtt: Double? = null,
-    val max_rtt: Double? = null,
-    val host_cpu: Double? = null,
+    //
+    val host_cpu: Double? = null, // we are taking max, since whole test must be repeated if load is too high
     val remote_cpu: Double? = null,
-    val retransmits: Long? = null,
+    //
     val is_udp: Boolean? = null,
-    val lost_packets: Long? = null,
-    val lost_percent: Double? = null,
-    val iperf_json: String? = null,
+    val iperf_ul_json: String? = null,
+    val iperf_dl_json: String? = null,
 ) {
     constructor (
         sessionId: String,
@@ -68,8 +82,10 @@ data class MeasurementItem(
         servingLte: LteNetworkInfo?,
         measuredAt: Long,
         system: SystemData,
-        iperf: IperfParsed?,
-        iperfRaw: String? = null,
+        iperfUl: IperfParsed?,
+        iperfDl: IperfParsed?,
+        iperfUlRaw: String? = null,
+        iperfDlRaw: String? = null,
     ) : this(
         session_id = sessionId,
         android_id = system.android_id,
@@ -91,25 +107,52 @@ data class MeasurementItem(
         battery_level = system.battery_level,
         battery_temp = system.battery_temp,
         os_version = system.os_version,
-        throughput_mbps = iperf?.throughputMbps,
-        latency_ms = iperf?.meanRtt,
-        jitter_ms = if (iperf?.maxRtt != null && iperf.minRtt != null) {
-            (iperf.maxRtt - iperf.minRtt)
+        //
+        // TODO: fix udp latency and jitter
+        ul_throughput_mbps = iperfUl?.throughputMbps,
+        ul_latency_ms = iperfUl?.meanRtt,
+        ul_jitter_ms = if (iperfUl?.maxRtt != null && iperfUl.minRtt != null) {
+            (iperfUl.maxRtt - iperfUl.minRtt)
         } else {
             null
         },
-        test_start_time = iperf?.startTime?.let { convertIperfTimeToIso(it) },
-        test_duration = iperf?.testDuration,
-        mean_rtt = iperf?.meanRtt,
-        min_rtt = iperf?.minRtt,
-        max_rtt = iperf?.maxRtt,
-        host_cpu = iperf?.hostCpuTotal,
-        remote_cpu = iperf?.remoteCpuTotal,
-        retransmits = iperf?.retransmits,
-        is_udp = iperf?.isUdp,
-        lost_packets = iperf?.lostPackets,
-        lost_percent = iperf?.lostPercent,
-        iperf_json = iperfRaw, // optional, normally empty
+        ul_mean_rtt = iperfUl?.meanRtt,
+        ul_min_rtt = iperfUl?.minRtt,
+        ul_max_rtt = iperfUl?.maxRtt,
+        ul_retransmits = iperfUl?.retransmits,
+        ul_lost_packets = iperfUl?.lostPackets,
+        ul_lost_percent = iperfUl?.lostPercent,
+        //
+        dl_throughput_mbps = iperfDl?.throughputMbps,
+        dl_latency_ms = iperfDl?.meanRtt,
+        dl_jitter_ms = if (iperfDl?.maxRtt != null && iperfDl.minRtt != null) {
+            (iperfDl.maxRtt - iperfDl.minRtt)
+        } else {
+            null
+        },
+        dl_mean_rtt = iperfDl?.meanRtt,
+        dl_min_rtt = iperfDl?.minRtt,
+        dl_max_rtt = iperfDl?.maxRtt,
+        dl_retransmits = iperfDl?.retransmits,
+        dl_lost_packets = iperfDl?.lostPackets,
+        dl_lost_percent = iperfDl?.lostPercent,
+        //
+        test_start_time = listOfNotNull(
+            iperfDl?.startTime?.let { convertIperfTimeToIso(it) },
+            iperfUl?.startTime?.let { convertIperfTimeToIso(it) },
+        ).minOrNull(),
+        test_duration = if (iperfUl?.testDuration != null || iperfDl?.testDuration != null) {
+            (iperfUl?.testDuration ?: 0.0) + (iperfDl?.testDuration ?: 0.0)
+        } else {
+            null
+        },
+        //
+        host_cpu = listOfNotNull(iperfUl?.hostCpuTotal, iperfDl?.hostCpuTotal).maxOrNull(),
+        remote_cpu = listOfNotNull(iperfUl?.remoteCpuTotal, iperfDl?.remoteCpuTotal).maxOrNull(),
+        //
+        is_udp = iperfUl?.isUdp,
+        iperf_ul_json = iperfUlRaw, // optional, normally empty
+        iperf_dl_json = iperfDlRaw, // optional, normally empty
     )
 
     companion object {
@@ -174,13 +217,15 @@ fun NetworkInfoData.toMeasurementsRequest(
     latitude: Double?,
     longitude: Double?,
     systemData: SystemData,
-    iperfRaw: String?,
+    iperfUlRaw: String?,
+    iperfDlRaw: String?,
     measuredAtNow: Long? = null,
 ): MeasurementRequest {
     val servingLte = lteCells.find { it.isServing }
     val servingNr = nrCells.find { it.isServing }
 
-    val iperfParsed = iperfRaw?.let { parseIperfJsonSafe(it) }
+    val iperfUlParsed = iperfUlRaw?.let { parseIperfJsonSafe(it) }
+    val iperfDlParsed = iperfDlRaw?.let { parseIperfJsonSafe(it) }
 
     val item = MeasurementItem(
         sessionId = sessionId,
@@ -191,8 +236,10 @@ fun NetworkInfoData.toMeasurementsRequest(
         servingLte = servingLte,
         measuredAt = measuredAtNow ?: System.currentTimeMillis(),
         system = systemData,
-        iperf = iperfParsed,
-        // iperfRaw = iperfRaw, // debug leftover
+        iperfUl = iperfUlParsed,
+        iperfDl = iperfDlParsed,
+        // iperfUlRaw = iperfUlRaw, // debug leftover
+        // iperfDlRaw = iperfDlRaw, // debug leftover
     )
 
     return MeasurementRequest(measurements = listOf(item))

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/iperf/IperfRunner.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/iperf/IperfRunner.kt
@@ -92,6 +92,16 @@ data class ThroughputPoint(
     val throughputMbps: Double,
 )
 
+data class RttPoint(
+    val timeEnd: Double,
+    val rtt: Double,
+)
+
+data class RttVarPoint(
+    val timeEnd: Double,
+    val rttvar: Double,
+)
+
 data class IperfParsed(
     val isUdp: Boolean,
     val throughputMbps: Double?,
@@ -107,6 +117,9 @@ data class IperfParsed(
     val testDuration: Double?,
     val retransmits: Long?, // TCP specific
     val throughputTimeline: List<ThroughputPoint>,
+    // timelines for calculating proper jitter in tcp
+    val rttTimeline: List<RttPoint>,
+    val rttVarTimeline: List<RttVarPoint>,
 )
 
 fun parseIperfJsonSafe(jsonString: String): IperfParsed? =
@@ -132,6 +145,9 @@ fun parseIperfJsonSafe(jsonString: String): IperfParsed? =
         val isUdp = protocol?.equals("UDP", ignoreCase = true) == true
 
         val timelinePoints = mutableListOf<ThroughputPoint>()
+        val rttPoints = mutableListOf<RttPoint>()
+        val rttVarPoints = mutableListOf<RttVarPoint>()
+
         val intervals = json["intervals"]?.jsonArray
 
         intervals?.forEach { intervalElement ->
@@ -147,6 +163,17 @@ fun parseIperfJsonSafe(jsonString: String): IperfParsed? =
                 if (timeEnd != null && bps != null) {
                     val mbps = bps / 1_000_000.0
                     timelinePoints.add(ThroughputPoint(timeEnd, mbps))
+                }
+            }
+            val firstStream = intervalObj["streams"]?.jsonArray?.firstOrNull()?.jsonObject
+            if (firstStream != null) {
+                val timeEnd = firstStream["end"]?.jsonPrimitive?.doubleOrNull
+                val rtt = firstStream["rtt"]?.jsonPrimitive?.doubleOrNull
+                val rttvar = firstStream["rttvar"]?.jsonPrimitive?.doubleOrNull
+
+                if (timeEnd != null) {
+                    if (rtt != null) rttPoints.add(RttPoint(timeEnd, rtt))
+                    if (rttvar != null) rttVarPoints.add(RttVarPoint(timeEnd, rttvar))
                 }
             }
         }
@@ -184,6 +211,8 @@ fun parseIperfJsonSafe(jsonString: String): IperfParsed? =
                 ?.jsonPrimitive
                 ?.longOrNull,
             throughputTimeline = timelinePoints,
+            rttTimeline = rttPoints,
+            rttVarTimeline = rttVarPoints,
         )
     } catch (_: Exception) {
         null

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/iperf/IperfRunner.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/iperf/IperfRunner.kt
@@ -103,7 +103,7 @@ data class RttVarPoint(
 )
 
 data class IperfParsed(
-    val isUdp: Boolean,
+    val protocol: String?,
     val throughputMbps: Double?,
     val meanRtt: Double?, // TCP specific
     val minRtt: Double?, // TCP specific
@@ -141,8 +141,12 @@ fun parseIperfJsonSafe(jsonString: String): IperfParsed? =
 
         val timestamp = start?.get("timestamp")?.jsonObject
         val testStart = start?.get("test_start")?.jsonObject
-        val protocol = testStart?.get("protocol")?.jsonPrimitive?.content
-        val isUdp = protocol?.equals("UDP", ignoreCase = true) == true
+
+        val protocol = testStart
+            ?.get("protocol")
+            ?.jsonPrimitive
+            ?.content
+            ?.uppercase()
 
         val timelinePoints = mutableListOf<ThroughputPoint>()
         val rttPoints = mutableListOf<RttPoint>()
@@ -179,7 +183,7 @@ fun parseIperfJsonSafe(jsonString: String): IperfParsed? =
         }
 
         IperfParsed(
-            isUdp = isUdp,
+            protocol = protocol,
             // Throughput mbps
             throughputMbps = sumReceived // f flag foes not affect json output
                 ?.get("bits_per_second")

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/iperf/IperfRunner.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/iperf/IperfRunner.kt
@@ -1,8 +1,11 @@
 package edu.pwr.zpi.netwalk.iperf
 
 // disable android optimization for these functions names
+import android.net.TrafficStats
 import androidx.annotation.Keep
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.doubleOrNull
@@ -38,32 +41,40 @@ object IperfRunner {
     external fun forceStopIperfTest(callback: IperfCallback)
 
     suspend fun runIperfOnce(command: Array<String>): String =
-        suspendCancellableCoroutine { cont ->
+        withContext(Dispatchers.IO) {
+            TrafficStats.setThreadStatsTag(0x00001000)
 
-            val outputBuffer = StringBuilder()
+            try {
+                suspendCancellableCoroutine { cont ->
 
-            val callback = object : IperfCallback {
-                override fun onOutput(message: String) {
-                    outputBuffer.append(message)
-                }
+                    val outputBuffer = StringBuilder()
 
-                override fun onError(error: String) {
-                    if (cont.isActive) {
-                        cont.resumeWithException(RuntimeException(error))
+                    val callback = object : IperfCallback {
+                        override fun onOutput(message: String) {
+                            outputBuffer.append(message)
+                        }
+
+                        override fun onError(error: String) {
+                            if (cont.isActive) {
+                                cont.resumeWithException(RuntimeException(error))
+                            }
+                        }
+
+                        override fun onComplete() {
+                            if (cont.isActive) {
+                                cont.resume(outputBuffer.toString())
+                            }
+                        }
+                    }
+
+                    runIperfLive(command, callback)
+
+                    cont.invokeOnCancellation {
+                        forceStopIperfTest(callback)
                     }
                 }
-
-                override fun onComplete() {
-                    if (cont.isActive) {
-                        cont.resume(outputBuffer.toString())
-                    }
-                }
-            }
-
-            runIperfLive(command, callback)
-
-            cont.invokeOnCancellation {
-                forceStopIperfTest(callback)
+            } finally {
+                TrafficStats.clearThreadStatsTag()
             }
         }
 }

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/iperf/IperfRunner.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/iperf/IperfRunner.kt
@@ -67,11 +67,19 @@ object IperfRunner {
                         }
                     }
 
-                    runIperfLive(command, callback)
-
                     cont.invokeOnCancellation {
                         forceStopIperfTest(callback)
                     }
+
+                    Thread {
+                        try {
+                            runIperfLive(command, callback)
+                        } catch (e: Exception) {
+                            if (cont.isActive) {
+                                cont.resumeWithException(e)
+                            }
+                        }
+                    }.start()
                 }
             } finally {
                 TrafficStats.clearThreadStatsTag()

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/iperf/IperfRunner.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/iperf/IperfRunner.kt
@@ -74,15 +74,19 @@ data class ThroughputPoint(
 )
 
 data class IperfParsed(
+    val isUdp: Boolean,
     val throughputMbps: Double?,
-    val meanRtt: Double?,
-    val minRtt: Double?,
+    val meanRtt: Double?, // TCP specific
+    val minRtt: Double?, // TCP specific
     val maxRtt: Double?,
+    val jitterMs: Double?, // directly from UDP
+    val lostPackets: Long?, // UDP specific
+    val lostPercent: Double?,
     val hostCpuTotal: Double?,
     val remoteCpuTotal: Double?,
     val startTime: String?,
     val testDuration: Double?,
-    val retransmits: Long?,
+    val retransmits: Long?, // TCP specific
     val throughputTimeline: List<ThroughputPoint>,
 )
 
@@ -104,6 +108,9 @@ fun parseIperfJsonSafe(jsonString: String): IperfParsed? =
         val senderStats = streamData?.get("sender")?.jsonObject
 
         val timestamp = start?.get("timestamp")?.jsonObject
+        val testStart = start?.get("test_start")?.jsonObject
+        val protocol = testStart?.get("protocol")?.jsonPrimitive?.content
+        val isUdp = protocol?.equals("UDP", ignoreCase = true) == true
 
         val timelinePoints = mutableListOf<ThroughputPoint>()
         val intervals = json["intervals"]?.jsonArray
@@ -126,23 +133,26 @@ fun parseIperfJsonSafe(jsonString: String): IperfParsed? =
         }
 
         IperfParsed(
+            isUdp = isUdp,
             // Throughput mbps
             throughputMbps = sumReceived // f flag foes not affect json output
                 ?.get("bits_per_second")
                 ?.jsonPrimitive
                 ?.doubleOrNull
                 ?.div(1_000_000.0),
-            // latency and jitter
+            // TCP latency and jitter
             meanRtt = senderStats?.get("mean_rtt")?.jsonPrimitive?.doubleOrNull,
             minRtt = senderStats?.get("min_rtt")?.jsonPrimitive?.doubleOrNull,
             maxRtt = senderStats?.get("max_rtt")?.jsonPrimitive?.doubleOrNull,
+            // UDP jitter and packet loss
+            jitterMs = sumReceived?.get("jitter_ms")?.jsonPrimitive?.doubleOrNull,
+            lostPackets = sumReceived?.get("lost_packets")?.jsonPrimitive?.longOrNull,
+            lostPercent = sumReceived?.get("lost_percent")?.jsonPrimitive?.doubleOrNull,
             // cpu utilization
             hostCpuTotal = cpuUtil?.get("host_total")?.jsonPrimitive?.doubleOrNull,
             remoteCpuTotal = cpuUtil?.get("remote_total")?.jsonPrimitive?.doubleOrNull,
             // timing
-            startTime = start
-                ?.get("timestamp")
-                ?.jsonObject
+            startTime = timestamp
                 ?.get("time")
                 ?.jsonPrimitive
                 ?.contentOrNull,

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/settings/SettingsRepository.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/settings/SettingsRepository.kt
@@ -41,7 +41,7 @@ class SettingsRepository(
 
     val serverUrl = PreferenceItem(stringPreferencesKey("server_url"), "http://10.0.2.2:8000")
     val iperfIp = PreferenceItem(stringPreferencesKey("iperf_ip"), "10.0.2.2")
-    val iperfPort = PreferenceItem(stringPreferencesKey("iperf_port"), "443")
+    val iperfPort = PreferenceItem(stringPreferencesKey("iperf_port"), "5201")
     val iperfTime = PreferenceItem(stringPreferencesKey("iperf_time"), "10")
     val iperfParallel = PreferenceItem(stringPreferencesKey("iperf_parallel"), "10")
     val packageSize = PreferenceItem(stringPreferencesKey("package_size"), "1500")

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/settings/SettingsRepository.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/settings/SettingsRepository.kt
@@ -44,6 +44,8 @@ class SettingsRepository(
     val iperfPort = PreferenceItem(stringPreferencesKey("iperf_port"), "443")
     val iperfTime = PreferenceItem(stringPreferencesKey("iperf_time"), "10")
     val iperfParallel = PreferenceItem(stringPreferencesKey("iperf_parallel"), "10")
+    val packageSize = PreferenceItem(stringPreferencesKey("package_size"), "1500")
+    val useUdp = PreferenceItem(booleanPreferencesKey("use_udp"), false)
 
     val passiveInterval = PreferenceItem(longPreferencesKey("passive_interval"), 3_000L)
 
@@ -52,5 +54,6 @@ class SettingsRepository(
 
     val sendImmediately = PreferenceItem(booleanPreferencesKey("send_immediately"), false)
 
+    // not exposed to ui
     val maxQueueSize = PreferenceItem(longPreferencesKey("max_queue_size"), 100L)
 }

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/settings/SettingsRepository.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/settings/SettingsRepository.kt
@@ -43,9 +43,12 @@ class SettingsRepository(
     val iperfIp = PreferenceItem(stringPreferencesKey("iperf_ip"), "10.0.2.2")
     val iperfPort = PreferenceItem(stringPreferencesKey("iperf_port"), "5201")
     val iperfTime = PreferenceItem(stringPreferencesKey("iperf_time"), "10")
-    val iperfParallel = PreferenceItem(stringPreferencesKey("iperf_parallel"), "10")
-    val packageSize = PreferenceItem(stringPreferencesKey("package_size"), "1500")
+    val iperfParallel = PreferenceItem(stringPreferencesKey("iperf_parallel"), "4")
+
     val useUdp = PreferenceItem(booleanPreferencesKey("use_udp"), false)
+    val packageSize = PreferenceItem(stringPreferencesKey("package_size"), "1000")
+    val targetBandwidth = PreferenceItem(stringPreferencesKey("target_bandwidth"), "100M")
+    val bufferLength = PreferenceItem(stringPreferencesKey("buffer_length"), "1000")
 
     val passiveInterval = PreferenceItem(longPreferencesKey("passive_interval"), 3_000L)
 

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
@@ -236,7 +236,7 @@ class NetworkViewModel(
         sendRequest = { request ->
 
             request.measurements.forEach { item ->
-                if (item.throughput_mbps != null || item.mean_rtt != null || item.retransmits != null) {
+                if (item.throughput_mbps != null || item.test_duration != null || item.is_udp != null) {
                     iperfLogEntries.add(
                         IperfLogEntry(
                             timestamp = item.measured_at,

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
@@ -236,13 +236,14 @@ class NetworkViewModel(
         sendRequest = { request ->
 
             request.measurements.forEach { item ->
-                if (item.throughput_mbps != null || item.test_duration != null || item.is_udp != null) {
+                if (item.test_duration != null || item.is_udp != null) {
                     iperfLogEntries.add(
+                        // TODO: actualize ui for up/down
                         IperfLogEntry(
                             timestamp = item.measured_at,
-                            throughputMbps = item.throughput_mbps,
-                            meanRtt = item.mean_rtt,
-                            retransmits = item.retransmits,
+                            throughputMbps = item.dl_throughput_mbps,
+                            meanRtt = item.dl_mean_rtt,
+                            retransmits = item.dl_retransmits,
                         ),
                     )
                 }
@@ -270,9 +271,12 @@ class NetworkViewModel(
         },
         shouldForceIperf = { forceIperfNow },
         onForceIperfHandled = { forceIperfNow = false },
-        onIperfRawResult = { rawJson ->
-            parseIperfJsonSafe(rawJson)?.let { parsedData ->
-                lastTestTimeline = parsedData.throughputTimeline
+        onIperfRawResult = { ulRawJson, dlRawJson ->
+            val activeJson = dlRawJson ?: ulRawJson
+            if (activeJson != null) {
+                parseIperfJsonSafe(activeJson)?.let { parsedData ->
+                    lastTestTimeline = parsedData.throughputTimeline
+                }
             }
         },
     )

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
@@ -235,7 +235,7 @@ class NetworkViewModel(
         sendRequest = { request ->
 
             request.measurements.forEach { item ->
-                if (item.test_duration != null || item.is_udp != null) {
+                if (item.test_duration != null || item.protocol != null) {
                     iperfLogEntries.add(
                         // TODO: actualize ui for up/down
                         IperfLogEntry(

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
@@ -237,7 +237,6 @@ class NetworkViewModel(
             request.measurements.forEach { item ->
                 if (item.test_duration != null || item.protocol != null) {
                     iperfLogEntries.add(
-                        // TODO: actualize ui for up/down
                         IperfLogEntry(
                             timestamp = item.measured_at,
                             throughputMbps = item.dl_throughput_mbps,
@@ -271,7 +270,10 @@ class NetworkViewModel(
         shouldForceIperf = { forceIperfNow },
         onForceIperfHandled = { forceIperfNow = false },
         onIperfRawResult = { ulRawJson, dlRawJson ->
-            val activeJson = dlRawJson ?: ulRawJson
+
+            // TODO: update plot to use both
+            val activeJson = dlRawJson ?: ulRawJson // for now using dl by default
+
             if (activeJson != null) {
                 parseIperfJsonSafe(activeJson)?.let { parsedData ->
                     lastTestTimeline = parsedData.throughputTimeline

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -225,7 +224,7 @@ class NetworkViewModel(
 
     private val collector = DataCollector(
         scope = viewModelScope,
-        getIperfCommand = { iperfCommand.value },
+        getIperfCommand = { isDownload -> iperfCommand(isDownload) },
         onStatusUpdate = { status -> lastStatus = status },
         onPassiveDataUpdate = { network, location, system ->
             uiStateNetwork = network
@@ -345,46 +344,51 @@ class NetworkViewModel(
         }
     }
 
-    val iperfCommand = uiSettingsState
-        .map { state ->
-            buildList {
-                add("iperf3")
-                add("-c")
-                add(state.iperfIp)
+    private fun iperfCommand(isDownload: Boolean): Array<String> {
+        val state = uiSettingsState.value
 
-                if (state.iperfPort.isNotBlank()) {
-                    add("-p")
-                    add(state.iperfPort)
-                }
+        val commandArray = buildList {
+            add("iperf3")
+            add("-c")
+            add(state.iperfIp)
 
-                if (state.useUdp) {
-                    add("-u")
+            if (state.iperfPort.isNotBlank()) {
+                add("-p")
+                add(state.iperfPort)
+            }
 
-                    add("-l")
-                    add(state.bufferLength)
+            if (state.useUdp) {
+                add("-u")
 
-                    add("-b")
-                    add(state.targetBandwidth)
-                } else {
-                    add("-M")
-                    add(state.packageSize)
-                }
+                add("-l")
+                add(state.bufferLength)
 
-                add("-t")
-                add(state.iperfTime)
+                add("-b")
+                add(state.targetBandwidth)
+            } else {
+                add("-M")
+                add(state.packageSize)
+            }
 
-                if (state.iperfParallel.isNotBlank()) {
-                    add("-P")
-                    add(state.iperfParallel)
-                }
+            add("-t")
+            add(state.iperfTime)
 
-                add("--json")
-            }.toTypedArray()
-        }.onEach { commandArray: Array<String> ->
-            Log.d("NetWalk", "Iperf command array: ${commandArray.joinToString(" ")}")
-        }.stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.Eagerly,
-            initialValue = arrayOf("iperf3"), // temporary fallback on init, reconstructed form default arguments later
-        )
+            if (state.iperfParallel.isNotBlank()) {
+                add("-P")
+                add(state.iperfParallel)
+            }
+
+            if (isDownload) {
+                add("-R")
+            }
+
+            add("--json")
+        }.toTypedArray()
+
+        // temporary fallback on init, reconstructed form default arguments later
+        val finalArray = if (state.iperfIp.isBlank()) arrayOf("iperf3") else commandArray
+        Log.d("NetWalk", "Iperf command array: ${commandArray.joinToString(" ")}")
+
+        return finalArray
+    }
 }

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
@@ -43,6 +43,8 @@ data class NetworkSettingsState(
     val iperfPort: String,
     val iperfTime: String,
     val iperfParallel: String,
+    val packageSize: String,
+    val useUdp: Boolean,
     val sendImmediately: Boolean,
 )
 
@@ -99,6 +101,8 @@ class NetworkViewModel(
         settings.iperfPort.flow,
         settings.iperfTime.flow,
         settings.iperfParallel.flow,
+        settings.packageSize.flow,
+        settings.useUdp.flow,
         settings.sendImmediately.flow,
     ) { values: Array<Any?> ->
         NetworkSettingsState(
@@ -107,7 +111,9 @@ class NetworkViewModel(
             iperfPort = values[2] as String,
             iperfTime = values[3] as String,
             iperfParallel = values[4] as String,
-            sendImmediately = values[5] as Boolean,
+            packageSize = values[5] as String,
+            useUdp = values[6] as Boolean,
+            sendImmediately = values[7] as Boolean,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -118,6 +124,8 @@ class NetworkViewModel(
             settings.iperfPort.defaultValue,
             settings.iperfTime.defaultValue,
             settings.iperfParallel.defaultValue,
+            settings.packageSize.defaultValue,
+            settings.useUdp.defaultValue,
             settings.sendImmediately.defaultValue,
         ),
     )
@@ -129,6 +137,8 @@ class NetworkViewModel(
             settings.iperfPort.update(state.iperfPort)
             settings.iperfTime.update(state.iperfTime)
             settings.iperfParallel.update(state.iperfParallel)
+            settings.packageSize.update(state.packageSize)
+            settings.useUdp.update(state.useUdp)
             settings.sendImmediately.update(state.sendImmediately)
         }
     }
@@ -139,6 +149,8 @@ class NetworkViewModel(
         settings.iperfPort.defaultValue,
         settings.iperfTime.defaultValue,
         settings.iperfParallel.defaultValue,
+        settings.packageSize.defaultValue,
+        settings.useUdp.defaultValue,
         settings.sendImmediately.defaultValue,
     )
 
@@ -315,35 +327,38 @@ class NetworkViewModel(
         }
     }
 
-    val iperfCommand = combine(
-        settings.iperfIp.flow,
-        settings.iperfPort.flow,
-        settings.iperfTime.flow,
-        settings.iperfParallel.flow,
-    ) { ip, port, time, parallel ->
-        buildList {
-            add("iperf3")
-            add("-c")
-            add(ip)
+    val iperfCommand = uiSettingsState
+        .map { state ->
+            buildList {
+                add("iperf3")
+                add("-c")
+                add(state.iperfIp)
 
-            if (port.isNotBlank()) {
-                add("-p")
-                add(port)
-            }
+                if (state.iperfPort.isNotBlank()) {
+                    add("-p")
+                    add(state.iperfPort)
+                }
 
-            add("-t")
-            add(time)
+                add("-t")
+                add(state.iperfTime)
 
-            if (parallel.isNotBlank()) {
-                add("-P")
-                add(parallel)
-            }
+                if (state.iperfParallel.isNotBlank()) {
+                    add("-P")
+                    add(state.iperfParallel)
+                }
 
-            add("--json")
-        }.toTypedArray()
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.Eagerly,
-        initialValue = arrayOf("iperf3"), // temporary fallback on init, reconstructed form default arguments later
-    )
+                if (state.useUdp) {
+                    add("-u")
+                }
+
+                add("-M")
+                add(state.packageSize)
+
+                add("--json")
+            }.toTypedArray()
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = arrayOf("iperf3"), // temporary fallback on init, reconstructed form default arguments later
+        )
 }

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
@@ -3,6 +3,7 @@ package edu.pwr.zpi.netwalk.ui
 import android.annotation.SuppressLint
 import android.content.Context
 import android.telephony.TelephonyManager
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -25,6 +26,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -44,6 +46,8 @@ data class NetworkSettingsState(
     val iperfTime: String,
     val iperfParallel: String,
     val packageSize: String,
+    val bufferLength: String,
+    val targetBandwidth: String,
     val useUdp: Boolean,
     val sendImmediately: Boolean,
 )
@@ -101,8 +105,10 @@ class NetworkViewModel(
         settings.iperfPort.flow,
         settings.iperfTime.flow,
         settings.iperfParallel.flow,
-        settings.packageSize.flow,
         settings.useUdp.flow,
+        settings.packageSize.flow,
+        settings.targetBandwidth.flow,
+        settings.bufferLength.flow,
         settings.sendImmediately.flow,
     ) { values: Array<Any?> ->
         NetworkSettingsState(
@@ -111,9 +117,11 @@ class NetworkViewModel(
             iperfPort = values[2] as String,
             iperfTime = values[3] as String,
             iperfParallel = values[4] as String,
-            packageSize = values[5] as String,
-            useUdp = values[6] as Boolean,
-            sendImmediately = values[7] as Boolean,
+            useUdp = values[5] as Boolean,
+            packageSize = values[6] as String,
+            targetBandwidth = values[7] as String,
+            bufferLength = values[8] as String,
+            sendImmediately = values[9] as Boolean,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -125,6 +133,8 @@ class NetworkViewModel(
             settings.iperfTime.defaultValue,
             settings.iperfParallel.defaultValue,
             settings.packageSize.defaultValue,
+            settings.targetBandwidth.defaultValue,
+            settings.bufferLength.defaultValue,
             settings.useUdp.defaultValue,
             settings.sendImmediately.defaultValue,
         ),
@@ -138,6 +148,8 @@ class NetworkViewModel(
             settings.iperfTime.update(state.iperfTime)
             settings.iperfParallel.update(state.iperfParallel)
             settings.packageSize.update(state.packageSize)
+            settings.targetBandwidth.update(state.targetBandwidth)
+            settings.bufferLength.update(state.bufferLength)
             settings.useUdp.update(state.useUdp)
             settings.sendImmediately.update(state.sendImmediately)
         }
@@ -150,6 +162,8 @@ class NetworkViewModel(
         settings.iperfTime.defaultValue,
         settings.iperfParallel.defaultValue,
         settings.packageSize.defaultValue,
+        settings.targetBandwidth.defaultValue,
+        settings.bufferLength.defaultValue,
         settings.useUdp.defaultValue,
         settings.sendImmediately.defaultValue,
     )
@@ -339,6 +353,19 @@ class NetworkViewModel(
                     add(state.iperfPort)
                 }
 
+                if (state.useUdp) {
+                    add("-u")
+
+                    add("-l")
+                    add(state.bufferLength)
+
+                    add("-b")
+                    add(state.targetBandwidth)
+                } else {
+                    add("-M")
+                    add(state.packageSize)
+                }
+
                 add("-t")
                 add(state.iperfTime)
 
@@ -347,15 +374,10 @@ class NetworkViewModel(
                     add(state.iperfParallel)
                 }
 
-                if (state.useUdp) {
-                    add("-u")
-                }
-
-                add("-M")
-                add(state.packageSize)
-
                 add("--json")
             }.toTypedArray()
+        }.onEach { commandArray: Array<String> ->
+            Log.d("NetWalk", "Iperf command array: ${commandArray.joinToString(" ")}")
         }.stateIn(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
@@ -203,6 +203,7 @@ fun SettingStringField(
     placeholder: String,
     isValid: (String) -> Boolean = { true },
     errorText: String = "Invalid input",
+    enabled: Boolean = true,
 ) {
     val isError = value.isNotEmpty() && !isValid(value)
 
@@ -214,6 +215,7 @@ fun SettingStringField(
         modifier = Modifier.fillMaxWidth(),
         singleLine = true,
         isError = isError,
+        enabled = enabled,
         supportingText = {
             if (isError) Text(errorText)
         },
@@ -227,6 +229,10 @@ fun SettingStringField(
             unfocusedTextColor = Color.White,
             focusedBorderColor = Color.White,
             unfocusedBorderColor = Color.Gray,
+            disabledTextColor = Color.Gray.copy(alpha = 0.5f),
+            disabledBorderColor = Color.DarkGray.copy(alpha = 0.3f),
+            disabledLabelColor = Color.Gray.copy(alpha = 0.5f),
+            disabledContainerColor = Color.Gray.copy(alpha = 0.1f),
             errorBorderColor = Color.Red,
             errorLabelColor = Color.Red,
         ),

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
@@ -108,6 +108,7 @@ fun SettingsScreen(
             placeholder = viewModel.defaults.iperfTime,
             isValid = ::isValidPositiveIntOrEmpty,
             errorText = "Must be a positive number.",
+            explanationText = "Duration of one-way test, final time may slightly exceed 2x of given value.",
         )
         SettingStringField(
             label = "Iperf Streams (-P)",

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
@@ -10,8 +10,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
@@ -130,6 +135,8 @@ fun SettingsScreen(
             value = editableSettings.packageSize,
             onValueChange = { editableSettings = editableSettings.copy(packageSize = it) },
             placeholder = viewModel.defaults.packageSize,
+            enabled = !editableSettings.useUdp,
+            explanationText = "Applied only then using TCP",
         )
 
         SettingStringField(
@@ -137,6 +144,8 @@ fun SettingsScreen(
             value = editableSettings.bufferLength,
             onValueChange = { editableSettings = editableSettings.copy(bufferLength = it) },
             placeholder = viewModel.defaults.bufferLength,
+            enabled = editableSettings.useUdp,
+            explanationText = "Applied only then using UDP",
         )
 
         SettingStringField(
@@ -144,8 +153,11 @@ fun SettingsScreen(
             value = editableSettings.targetBandwidth,
             onValueChange = { editableSettings = editableSettings.copy(targetBandwidth = it) },
             placeholder = viewModel.defaults.targetBandwidth,
+            enabled = editableSettings.useUdp,
+            explanationText = "Applied only then using UDP",
         )
 
+        var showSendImmediatelyExplanation by remember { mutableStateOf(false) }
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth(),
@@ -160,6 +172,28 @@ fun SettingsScreen(
                 text = "Send immediately",
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(start = 6.dp),
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            IconButton(onClick = { showSendImmediatelyExplanation = true }) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = "Explanation for Send Immediately",
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+        if (showSendImmediatelyExplanation) {
+            AlertDialog(
+                onDismissRequest = { showSendImmediatelyExplanation = false },
+                title = { Text("Send immediately") },
+                text = { Text("Send measurements immediately, without queueing.") },
+                confirmButton = {
+                    TextButton(onClick = { showSendImmediatelyExplanation = false }) {
+                        Text("OK")
+                    }
+                },
             )
         }
 
@@ -204,8 +238,11 @@ fun SettingStringField(
     isValid: (String) -> Boolean = { true },
     errorText: String = "Invalid input",
     enabled: Boolean = true,
+    explanationText: String? = null,
 ) {
     val isError = value.isNotEmpty() && !isValid(value)
+
+    var showExplanation by remember { mutableStateOf(false) }
 
     OutlinedTextField(
         value = value,
@@ -216,6 +253,19 @@ fun SettingStringField(
         singleLine = true,
         isError = isError,
         enabled = enabled,
+        trailingIcon = if (explanationText != null) {
+            {
+                IconButton(onClick = { showExplanation = true }) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = "Info",
+                        tint = if (enabled) MaterialTheme.colorScheme.primary else Color.Gray,
+                    )
+                }
+            }
+        } else {
+            null
+        },
         supportingText = {
             if (isError) Text(errorText)
         },
@@ -237,6 +287,19 @@ fun SettingStringField(
             errorLabelColor = Color.Red,
         ),
     )
+
+    if (showExplanation && explanationText != null) {
+        AlertDialog(
+            onDismissRequest = { showExplanation = false },
+            title = { Text(label) },
+            text = { Text(explanationText) },
+            confirmButton = {
+                TextButton(onClick = { showExplanation = false }) {
+                    Text("OK")
+                }
+            },
+        )
+    }
 }
 
 private fun isValidUrl(url: String): Boolean =

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
@@ -105,12 +105,16 @@ fun SettingsScreen(
             value = editableSettings.iperfTime,
             onValueChange = { editableSettings = editableSettings.copy(iperfTime = it) },
             placeholder = viewModel.defaults.iperfTime,
+            isValid = ::isValidPositiveIntOrEmpty,
+            errorText = "Must be a positive number.",
         )
         SettingStringField(
             label = "Iperf Streams (-P)",
             value = editableSettings.iperfParallel,
             onValueChange = { editableSettings = editableSettings.copy(iperfParallel = it) },
             placeholder = viewModel.defaults.iperfParallel,
+            isValid = ::isValidPositiveIntOrEmpty,
+            errorText = "Must be a positive number.",
         )
 
         Row(
@@ -137,6 +141,8 @@ fun SettingsScreen(
             placeholder = viewModel.defaults.packageSize,
             enabled = !editableSettings.useUdp,
             explanationText = "Applied only then using TCP",
+            isValid = ::isValidSizeFormatOrEmpty,
+            errorText = "Invalid size (e.g., 500, 1K).",
         )
 
         SettingStringField(
@@ -146,6 +152,8 @@ fun SettingsScreen(
             placeholder = viewModel.defaults.bufferLength,
             enabled = editableSettings.useUdp,
             explanationText = "Applied only then using UDP",
+            isValid = ::isValidSizeFormatOrEmpty,
+            errorText = "Invalid size (e.g., 500, 1K).",
         )
 
         SettingStringField(
@@ -155,6 +163,8 @@ fun SettingsScreen(
             placeholder = viewModel.defaults.targetBandwidth,
             enabled = editableSettings.useUdp,
             explanationText = "Applied only then using UDP",
+            isValid = ::isValidSizeFormatOrEmpty,
+            errorText = "Invalid size (e.g., 500, 1K).",
         )
 
         var showSendImmediatelyExplanation by remember { mutableStateOf(false) }
@@ -323,4 +333,16 @@ private fun isValidPort(port: String): Boolean {
     if (port.isEmpty()) return true // allow empty port if using public iperf server
     val portInt = port.toIntOrNull() ?: return false
     return portInt in 1..65535
+}
+
+private fun isValidPositiveIntOrEmpty(value: String): Boolean {
+    if (value.isEmpty()) return true
+    val intVal = value.toIntOrNull() ?: return false
+    return intVal > 0
+}
+
+private fun isValidSizeFormatOrEmpty(value: String): Boolean {
+    if (value.isEmpty()) return true
+    val regex = """^\d+(\.\d+)?[kKmMgG]?$""".toRegex()
+    return regex.matches(value)
 }

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package edu.pwr.zpi.netwalk.ui
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -32,6 +33,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -207,12 +209,14 @@ fun SettingsScreen(
             )
         }
 
+        val context = LocalContext.current
+
         Button(
             onClick = {
                 scope.launch {
                     viewModel.saveAllSettings(editableSettings)
 
-                    saveStatus = "Saved"
+                    Toast.makeText(context, "Saved", Toast.LENGTH_SHORT).show()
                 }
             },
             modifier = Modifier.align(Alignment.End),

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
@@ -101,7 +101,6 @@ fun SettingsScreen(
             isValid = ::isValidPort,
         )
 
-        // TODO: disable flag change support option in future
         SettingStringField(
             label = "Iperf Length (-t)",
             value = editableSettings.iperfTime,

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
@@ -107,12 +107,6 @@ fun SettingsScreen(
             onValueChange = { editableSettings = editableSettings.copy(iperfParallel = it) },
             placeholder = viewModel.defaults.iperfParallel,
         )
-        SettingStringField(
-            label = "Iperf max package size (-M)",
-            value = editableSettings.packageSize,
-            onValueChange = { editableSettings = editableSettings.copy(packageSize = it) },
-            placeholder = viewModel.defaults.packageSize,
-        )
 
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -130,6 +124,27 @@ fun SettingsScreen(
                 modifier = Modifier.padding(start = 6.dp),
             )
         }
+
+        SettingStringField(
+            label = "Iperf max package size (-M)",
+            value = editableSettings.packageSize,
+            onValueChange = { editableSettings = editableSettings.copy(packageSize = it) },
+            placeholder = viewModel.defaults.packageSize,
+        )
+
+        SettingStringField(
+            label = "Iperf buffer length (-l)",
+            value = editableSettings.bufferLength,
+            onValueChange = { editableSettings = editableSettings.copy(bufferLength = it) },
+            placeholder = viewModel.defaults.bufferLength,
+        )
+
+        SettingStringField(
+            label = "Iperf target bandwidth (-b)",
+            value = editableSettings.targetBandwidth,
+            onValueChange = { editableSettings = editableSettings.copy(targetBandwidth = it) },
+            placeholder = viewModel.defaults.targetBandwidth,
+        )
 
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
@@ -107,6 +107,29 @@ fun SettingsScreen(
             onValueChange = { editableSettings = editableSettings.copy(iperfParallel = it) },
             placeholder = viewModel.defaults.iperfParallel,
         )
+        SettingStringField(
+            label = "Iperf max package size (-M)",
+            value = editableSettings.packageSize,
+            onValueChange = { editableSettings = editableSettings.copy(packageSize = it) },
+            placeholder = viewModel.defaults.packageSize,
+        )
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Checkbox(
+                checked = editableSettings.useUdp,
+                onCheckedChange = { checked ->
+                    editableSettings = editableSettings.copy(useUdp = checked)
+                },
+            )
+            Text(
+                text = "Use UDP protocol (-u)",
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(start = 6.dp),
+            )
+        }
 
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
+++ b/androidApp/app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/SettingsScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
@@ -51,15 +53,18 @@ fun SettingsScreen(
     val scope = rememberCoroutineScope()
     var saveStatus by remember { mutableStateOf<String?>(null) }
 
+    val scrollState = rememberScrollState()
+
     Column(
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
         modifier = Modifier
             .fillMaxSize()
+            .verticalScroll(scrollState)
             .padding(8.dp),
     ) {
         Text(
             text = "Server Configuration",
-            modifier = Modifier.padding(bottom = 8.dp),
+            modifier = Modifier.padding(bottom = 6.dp),
             color = MaterialTheme.colorScheme.primary,
         )
 
@@ -82,7 +87,7 @@ fun SettingsScreen(
         )
 
         SettingStringField(
-            label = "Iperf Port",
+            label = "Iperf Port (-p)",
             value = editableSettings.iperfPort,
             onValueChange = { editableSettings = editableSettings.copy(iperfPort = it) },
             placeholder = viewModel.defaults.iperfPort,
@@ -91,13 +96,13 @@ fun SettingsScreen(
 
         // TODO: disable flag change support option in future
         SettingStringField(
-            label = "Iperf Length",
+            label = "Iperf Length (-t)",
             value = editableSettings.iperfTime,
             onValueChange = { editableSettings = editableSettings.copy(iperfTime = it) },
             placeholder = viewModel.defaults.iperfTime,
         )
         SettingStringField(
-            label = "Iperf Streams",
+            label = "Iperf Streams (-P)",
             value = editableSettings.iperfParallel,
             onValueChange = { editableSettings = editableSettings.copy(iperfParallel = it) },
             placeholder = viewModel.defaults.iperfParallel,
@@ -116,7 +121,7 @@ fun SettingsScreen(
             Text(
                 text = "Send immediately",
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(start = 8.dp),
+                modifier = Modifier.padding(start = 6.dp),
             )
         }
 
@@ -141,7 +146,7 @@ fun SettingsScreen(
             )
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(6.dp))
 
         TextButton(
             onClick = onNavigateBack,

--- a/androidApp/app/src/main/res/xml/network_security_config.xml
+++ b/androidApp/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
Again, sorry za duży pr, ale nie da się je tak łatwo rozdzielić bo równolegle testowałem rzeczy na poziomie c i jni, i poprawiałem ui + robiłem uplink/downlink

Mógłbyś proszę zaktualizować te wykresy żeby wyświetlały oba uplink i downlink, w 275 po prostu wybieram ten na down, trzeba w sygnaturach dodać.
```
app/src/main/kotlin/edu/pwr/zpi/netwalk/ui/NetworkViewModel.kt
271-        onForceIperfHandled = { forceIperfNow = false },
272-        onIperfRawResult = { ulRawJson, dlRawJson ->
273-
274:            // TODO: update plot to use both
275-            val activeJson = dlRawJson ?: ulRawJson // for now using dl by default
276-
277-            if (activeJson != null) {
```

I jeżeli dasz radę to zrobić indykator z tym czy API server jest podłączony, bo tobie ui lepiej wychodzi, imo wystaczy przy pasywnym teście robić ping na /health i będzie git.