### PR TITLE
dodny ipref3 na porty kolejne

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -60,6 +60,27 @@ services:
     restart: always
     networks:
       - netwalk-network
+  iperf3-2:
+    image: networkstatic/iperf3
+    container_name: netwalk-iperf-2
+    ports:
+      - "5202:5201/tcp"
+      - "5202:5201/udp"
+    command: [ "-s" ]
+    restart: always
+    networks:
+      - netwalk-network
+
+  iperf3-3:
+    image: networkstatic/iperf3
+    container_name: netwalk-iperf-3
+    ports:
+      - "5203:5201/tcp"
+      - "5203:5201/udp"
+    command: [ "-s" ]
+    restart: always
+    networks:
+      - netwalk-network
 
   tests:
     build:


### PR DESCRIPTION
o ile dobrze zrozumiałam to każdy kontener ma nasłuchiwać wewnętrznie na porcie 5201 ale jest dostępny z zewnątrz na innych portach - dodałam 2 bo mamy w sumie 3 telefony