### PR TITLE
Jakkolwiek działający dispatcher dla iperfa

### DIFF
--- a/backend/iperf-nginx.conf
+++ b/backend/iperf-nginx.conf
@@ -1,0 +1,36 @@
+user nginx;
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+stream {
+    upstream iperf_tcp_backends {
+        hash $remote_addr; # should enforce ip sticky-ness
+
+        server netwalk-iperf:5201;
+        server netwalk-iperf-2:5201;
+        server netwalk-iperf-3:5201;
+    }
+
+    upstream iperf_udp_backends {
+        hash $remote_addr;
+
+        server netwalk-iperf:5201;
+        server netwalk-iperf-2:5201;
+        server netwalk-iperf-3:5201;
+    }
+
+    server {
+        listen 5201;
+        proxy_pass iperf_tcp_backends;
+        proxy_timeout 10m; # session keep-alive timeout
+    }
+
+    server {
+        listen 5201 udp;
+        proxy_pass iperf_udp_backends;
+        proxy_timeout 10m;
+    }
+}

--- a/backend/iperf-nginx.conf
+++ b/backend/iperf-nginx.conf
@@ -5,7 +5,9 @@ events {
 }
 
 stream {
+    error_log stderr warn;
     lua_shared_dict iperf_locks 10m;
+
 
     upstream backend_pool {
         server 0.0.0.1:12345;
@@ -15,38 +17,30 @@ stream {
             local locks = ngx.shared.iperf_locks
             local client_ip = ngx.var.remote_addr
 
-            -- Direct mapping to the localhost ports exposed by docker-compose
-            local backend_ports = {5201, 5202, 5203}
-            local assigned_idx = locks:get(client_ip)
+            local backend_ports = {5202, 5203, 5204}
+
+            local assigned_idx = locks:get(client_ip .. "_idx")
 
             if not assigned_idx then
-                local backend_usage = {false, false, false}
-                local keys = locks:get_keys(0)
-
-                for _, ip in ipairs(keys) do
-                    local idx = locks:get(ip)
-                    if idx and ip ~= client_ip then
-                        backend_usage[idx] = true
-                    end
-                end
-
-                for i, is_busy in ipairs(backend_usage) do
-                    if not is_busy then
+                for i = 1, #backend_ports do
+                    local ok, err = locks:add("backend_locked_" .. i, client_ip, 900)
+                    if ok then
                         assigned_idx = i
+                        locks:set(client_ip .. "_idx", assigned_idx, 900)
                         break
                     end
                 end
 
                 if not assigned_idx then
+                    math.randomseed(ngx.now() * 1000 + ngx.worker.pid())
                     assigned_idx = math.random(#backend_ports)
+                    locks:set(client_ip .. "_idx", assigned_idx, 900)
                 end
-
-                locks:set(client_ip, assigned_idx, 60)
             end
 
-            local target_port = backend_ports[assigned_idx]
+            locks:incr(client_ip .. "_conns", 1, 0)
 
-            -- Connect directly to the host loopback IP where iperf3 containers are listening
+            local target_port = backend_ports[assigned_idx]
             local ok, set_err = balancer.set_current_peer("127.0.0.1", target_port)
             if not ok then
                 ngx.log(ngx.ERR, "Failed to set peer socket: ", set_err)
@@ -61,9 +55,28 @@ stream {
 
         proxy_pass backend_pool;
 
-        proxy_half_close on; # TODO: verify if needed
+        proxy_half_close on;
 
         proxy_connect_timeout 2s;
-        proxy_timeout 2s;
+        proxy_timeout 10m;
+
+        log_by_lua_block {
+            local locks = ngx.shared.iperf_locks
+            local client_ip = ngx.var.remote_addr
+
+            local new_count, err = locks:incr(client_ip .. "_conns", -1)
+
+            if new_count and new_count <= 0 then
+                local assigned_idx = locks:get(client_ip .. "_idx")
+                if assigned_idx then
+                    local lock_owner = locks:get("backend_locked_" .. assigned_idx)
+                    if lock_owner == client_ip then
+                        locks:delete("backend_locked_" .. assigned_idx)
+                    end
+                end
+                locks:delete(client_ip .. "_idx")
+                locks:delete(client_ip .. "_conns")
+            end
+        }
     }
 }

--- a/backend/iperf-nginx.conf
+++ b/backend/iperf-nginx.conf
@@ -1,4 +1,3 @@
-user nginx;
 worker_processes auto;
 
 events {
@@ -6,31 +5,65 @@ events {
 }
 
 stream {
-    upstream iperf_tcp_backends {
-        hash $remote_addr; # should enforce ip sticky-ness
+    lua_shared_dict iperf_locks 10m;
 
-        server netwalk-iperf:5201;
-        server netwalk-iperf-2:5201;
-        server netwalk-iperf-3:5201;
-    }
+    upstream backend_pool {
+        server 0.0.0.1:12345;
 
-    upstream iperf_udp_backends {
-        hash $remote_addr;
+        balancer_by_lua_block {
+            local balancer = require "ngx.balancer"
+            local locks = ngx.shared.iperf_locks
+            local client_ip = ngx.var.remote_addr
 
-        server netwalk-iperf:5201;
-        server netwalk-iperf-2:5201;
-        server netwalk-iperf-3:5201;
+            -- Direct mapping to the localhost ports exposed by docker-compose
+            local backend_ports = {5201, 5202, 5203}
+            local assigned_idx = locks:get(client_ip)
+
+            if not assigned_idx then
+                local backend_usage = {false, false, false}
+                local keys = locks:get_keys(0)
+
+                for _, ip in ipairs(keys) do
+                    local idx = locks:get(ip)
+                    if idx and ip ~= client_ip then
+                        backend_usage[idx] = true
+                    end
+                end
+
+                for i, is_busy in ipairs(backend_usage) do
+                    if not is_busy then
+                        assigned_idx = i
+                        break
+                    end
+                end
+
+                if not assigned_idx then
+                    assigned_idx = math.random(#backend_ports)
+                end
+
+                locks:set(client_ip, assigned_idx, 60)
+            end
+
+            local target_port = backend_ports[assigned_idx]
+
+            -- Connect directly to the host loopback IP where iperf3 containers are listening
+            local ok, set_err = balancer.set_current_peer("127.0.0.1", target_port)
+            if not ok then
+                ngx.log(ngx.ERR, "Failed to set peer socket: ", set_err)
+                return ngx.exit(500)
+            end
+        }
     }
 
     server {
         listen 5201;
-        proxy_pass iperf_tcp_backends;
-        proxy_timeout 10m; # session keep-alive timeout
-    }
-
-    server {
         listen 5201 udp;
-        proxy_pass iperf_udp_backends;
-        proxy_timeout 10m;
+
+        proxy_pass backend_pool;
+
+        proxy_half_close on; # TODO: verify if needed
+
+        proxy_connect_timeout 2s;
+        proxy_timeout 2s;
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,41 +51,39 @@ services:
       - netwalk-network
 
   iperf-proxy:
-    image: nginx:1.31-alpine3.23
+    image: openresty/openresty:1.25.3.1-alpine-fat-amd64
     container_name: netwalk-iperf-proxy
-    ports:
-      - "5201:5201/tcp"
-      - "5201:5201/udp"
+    network_mode: host
     volumes:
-      - ./backend/iperf-nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./backend/iperf-nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
     depends_on:
       - iperf3
       - iperf3-2
       - iperf3-3
-    networks:
-      - netwalk-network
-
   iperf3:
     image: networkstatic/iperf3
     container_name: netwalk-iperf
     command: ["-s"]
     restart: always
-    networks:
-      - netwalk-network
+    ports:
+      - "127.0.0.1:5202:5201/tcp"
+      - "127.0.0.1:5202:5201/udp"
   iperf3-2:
     image: networkstatic/iperf3
     container_name: netwalk-iperf-2
     command: ["-s"]
     restart: always
-    networks:
-      - netwalk-network
+    ports:
+      - "127.0.0.1:5203:5201/tcp"
+      - "127.0.0.1:5203:5201/udp"
   iperf3-3:
     image: networkstatic/iperf3
     container_name: netwalk-iperf-3
     command: ["-s"]
     restart: always
-    networks:
-      - netwalk-network
+    ports:
+      - "127.0.0.1:5204:5201/tcp"
+      - "127.0.0.1:5204:5201/udp"
 
   tests:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
   iperf3:
     image: networkstatic/iperf3
     container_name: netwalk-iperf
-    command: ["-s"]
+    command: ["-s", "-p", "5201", "--one-off", "--idle-timeout", "30"]
     restart: always
     ports:
       - "127.0.0.1:5202:5201/tcp"
@@ -71,7 +71,7 @@ services:
   iperf3-2:
     image: networkstatic/iperf3
     container_name: netwalk-iperf-2
-    command: ["-s"]
+    command: ["-s", "-p", "5201", "--one-off", "--idle-timeout", "30"]
     restart: always
     ports:
       - "127.0.0.1:5203:5201/tcp"
@@ -79,7 +79,7 @@ services:
   iperf3-3:
     image: networkstatic/iperf3
     container_name: netwalk-iperf-3
-    command: ["-s"]
+    command: ["-s", "-p", "5201", "--one-off", "--idle-timeout", "30"]
     restart: always
     ports:
       - "127.0.0.1:5204:5201/tcp"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     container_name: netwalk-api
     ports:
       - "8000:8000" # api exposed to host at 8000
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     env_file:
       - .env
     environment:
@@ -48,25 +50,24 @@ services:
     networks:
       - netwalk-network
 
-  frontend:
-    build:
-      context: ./frontend
-    container_name: netwalk-frontend
+  iperf-proxy:
+    image: nginx:1.31-alpine3.23
+    container_name: netwalk-iperf-proxy
     ports:
-      - "8080:80" # nginx exposed to host at 8000
+      - "5201:5201/tcp"
+      - "5201:5201/udp"
     volumes:
-      - ./frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./backend/iperf-nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
-      - api
+      - iperf3
+      - iperf3-2
+      - iperf3-3
     networks:
       - netwalk-network
 
   iperf3:
     image: networkstatic/iperf3
     container_name: netwalk-iperf
-    ports:
-      - "5201:5201/tcp"
-      - "5201:5201/udp"
     command: ["-s"]
     restart: always
     networks:
@@ -74,9 +75,6 @@ services:
   iperf3-2:
     image: networkstatic/iperf3
     container_name: netwalk-iperf-2
-    ports:
-      - "5202:5201/tcp"
-      - "5202:5201/udp"
     command: ["-s"]
     restart: always
     networks:
@@ -84,9 +82,6 @@ services:
   iperf3-3:
     image: networkstatic/iperf3
     container_name: netwalk-iperf-3
-    ports:
-      - "5203:5201/tcp"
-      - "5203:5201/udp"
     command: ["-s"]
     restart: always
     networks:
@@ -110,6 +105,19 @@ services:
         condition: service_healthy
     profiles:
       - test
+    networks:
+      - netwalk-network
+
+  frontend:
+    build:
+      context: ./frontend
+    container_name: netwalk-frontend
+    ports:
+      - "8080:80" # nginx exposed to host at 8000
+    volumes:
+      - ./frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - api
     networks:
       - netwalk-network
 


### PR DESCRIPTION
Dalej czasami nie przepuszcza rownoległych testów, ale jest as goob as it can gets
lepiej nie zrobie, zwłaszca w tym czasie 

+ restart contenerów na timeout